### PR TITLE
Fix state assignment in device readiness check

### DIFF
--- a/lib/mqtt/homie/device.rb
+++ b/lib/mqtt/homie/device.rb
@@ -140,7 +140,7 @@ module MQTT
 
           yield if block_given?
 
-          state == :ready
+          self.state = :ready
         end
 
         @published = true


### PR DESCRIPTION
We accidentally had a predicate instead of assignment, leading to the ready state never getting published.